### PR TITLE
add img tag support, as well as a helper to just fetch the asset url

### DIFF
--- a/helper/helper.go
+++ b/helper/helper.go
@@ -15,6 +15,10 @@ func ScriptTag(url string) string {
 	return `<script type="text/javascript" src="` + html.EscapeString(url) + `"></script>`
 }
 
+func ImgTag(url string) string {
+	return `<img src="` + html.EscapeString(url) + `"></img>`
+}
+
 // AssetTag make js or css tag from url
 func AssetTag(kind, url string) string {
 	var buf string
@@ -22,6 +26,8 @@ func AssetTag(kind, url string) string {
 		buf = LinkTag(url)
 	} else if kind == "js" {
 		buf = ScriptTag(url)
+	} else if kind == "png" || kind == "svg" {
+		buf = ImgTag(url)
 	} else {
 		log.Println("go-webpack: unsupported asset kind: " + kind)
 		buf = ""

--- a/webpack.go
+++ b/webpack.go
@@ -50,7 +50,11 @@ type Config struct {
 	AssetHost string
 }
 
-var AssetHelper func(string) (template.HTML, error)
+type AssetTagHelperFunc func(string) (template.HTML, error)
+type AssetURLHelperFunc func(string) (string, error)
+
+var AssetTagHelper AssetTagHelperFunc
+var AssetURLHelper AssetURLHelperFunc
 
 // Init Set current environment and preload manifest
 func Init(dev bool) error {
@@ -61,7 +65,7 @@ func Init(dev bool) error {
 	}
 
 	var err error
-	AssetHelper, err = GetAssetHelper(&Config{
+	AssetTagHelper, AssetURLHelper, err = GetAssetHelpers(&Config{
 		DevHost:       DevHost,
 		FsPath:        FsPath,
 		WebPath:       WebPath,
@@ -93,7 +97,7 @@ func readManifest(conf *Config) (map[string][]string, error) {
 	return reader.Read(conf.Plugin, conf.DevHost, conf.FsPath, conf.WebPath, conf.IsDev)
 }
 
-func GetAssetHelper(conf *Config) (func(string) (template.HTML, error), error) {
+func GetAssetHelpers(conf *Config) (AssetTagHelperFunc, AssetURLHelperFunc, error) {
 	preloadedAssets := map[string][]string{}
 
 	var err error
@@ -107,14 +111,14 @@ func GetAssetHelper(conf *Config) (func(string) (template.HTML, error), error) {
 		preloadedAssets, err = readManifest(conf)
 		// we won't ever re-check assets in this case.  this should be a hard error.
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 	}
 
-	return createAssetHelper(conf, preloadedAssets), nil
+	return createAssetTagHelper(conf, preloadedAssets), createAssetURLHelper(conf, preloadedAssets), nil
 }
 
-func createAssetHelper(conf *Config, preloadedAssets map[string][]string) func(string) (template.HTML, error) {
+func createAssetTagHelper(conf *Config, preloadedAssets map[string][]string) AssetTagHelperFunc {
 	return func(key string) (template.HTML, error) {
 		var err error
 
@@ -160,5 +164,55 @@ func createAssetHelper(conf *Config, preloadedAssets map[string][]string) func(s
 			}
 		}
 		return template.HTML(strings.Join(buf, "\n")), nil
+	}
+}
+
+func createAssetURLHelper(conf *Config, preloadedAssets map[string][]string) AssetURLHelperFunc {
+	return func(key string) (string, error) {
+		var err error
+
+		var assets map[string][]string
+		if conf.IsDev {
+			assets, err = readManifest(conf)
+			if err != nil {
+				return "", err
+			}
+		} else {
+			assets = preloadedAssets
+		}
+
+		parts := strings.Split(key, ".")
+		kind := parts[len(parts)-1]
+		//log.Println("showing assets:", key, parts, kind)
+
+		v, ok := assets[key]
+		if !ok {
+			message := "go-webpack: Asset file '" + key + "' not found in manifest"
+			if conf.Verbose {
+				log.Printf("%s. Manifest contents:", message)
+				for k, a := range assets {
+					log.Printf("%s: %s", k, a)
+				}
+			}
+			if conf.IgnoreMissing {
+				return "", nil
+			}
+			return "", errors.New(message)
+		}
+
+		buf := []string{}
+		for _, s := range v {
+			if strings.HasSuffix(s, "."+kind) {
+				url := s
+				if len(conf.AssetHost) > 0 {
+					url = conf.AssetHost + url
+				}
+				buf = append(buf, url)
+			} else {
+				log.Println("skip asset", s, ": bad type")
+			}
+		}
+		// this seems very wrong for multiple urls, but we don't have that problem right now :grimacing:
+		return strings.Join(buf, ","), nil
 	}
 }

--- a/webpack.go
+++ b/webpack.go
@@ -118,50 +118,63 @@ func GetAssetHelpers(conf *Config) (AssetTagHelperFunc, AssetURLHelperFunc, erro
 	return createAssetTagHelper(conf, preloadedAssets), createAssetURLHelper(conf, preloadedAssets), nil
 }
 
+func getValues(key, kind string, conf *Config, preloadedAssets map[string][]string) ([]string, error) {
+	var err error
+
+	var assets map[string][]string
+	if conf.IsDev {
+		assets, err = readManifest(conf)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		assets = preloadedAssets
+	}
+
+	v, ok := assets[key]
+	if !ok {
+		message := "go-webpack: Asset file '" + key + "' not found in manifest"
+		if conf.Verbose {
+			log.Printf("%s. Manifest contents:", message)
+			for k, a := range assets {
+				log.Printf("%s: %s", k, a)
+			}
+		}
+		if conf.IgnoreMissing {
+			return nil, nil
+		}
+		return nil, errors.New(message)
+	}
+
+	values := []string{}
+	for _, s := range v {
+		if strings.HasSuffix(s, "."+kind) {
+			url := s
+			if len(conf.AssetHost) > 0 {
+				url = conf.AssetHost + url
+			}
+			values = append(values, url)
+		} else {
+			log.Println("skip asset", s, ": bad type")
+		}
+	}
+
+	return values, nil
+}
+
 func createAssetTagHelper(conf *Config, preloadedAssets map[string][]string) AssetTagHelperFunc {
 	return func(key string) (template.HTML, error) {
-		var err error
-
-		var assets map[string][]string
-		if conf.IsDev {
-			assets, err = readManifest(conf)
-			if err != nil {
-				return template.HTML(""), err
-			}
-		} else {
-			assets = preloadedAssets
-		}
-
 		parts := strings.Split(key, ".")
 		kind := parts[len(parts)-1]
-		//log.Println("showing assets:", key, parts, kind)
 
-		v, ok := assets[key]
-		if !ok {
-			message := "go-webpack: Asset file '" + key + "' not found in manifest"
-			if conf.Verbose {
-				log.Printf("%s. Manifest contents:", message)
-				for k, a := range assets {
-					log.Printf("%s: %s", k, a)
-				}
-			}
-			if conf.IgnoreMissing {
-				return template.HTML(""), nil
-			}
-			return template.HTML(""), errors.New(message)
+		urls, err := getValues(key, kind, conf, preloadedAssets)
+		if err != nil {
+			return template.HTML(""), err
 		}
 
 		buf := []string{}
-		for _, s := range v {
-			if strings.HasSuffix(s, "."+kind) {
-				url := s
-				if len(conf.AssetHost) > 0 {
-					url = conf.AssetHost + url
-				}
-				buf = append(buf, helper.AssetTag(kind, url))
-			} else {
-				log.Println("skip asset", s, ": bad type")
-			}
+		for _, url := range urls {
+			buf = append(buf, helper.AssetTag(kind, url))
 		}
 		return template.HTML(strings.Join(buf, "\n")), nil
 	}
@@ -169,48 +182,17 @@ func createAssetTagHelper(conf *Config, preloadedAssets map[string][]string) Ass
 
 func createAssetURLHelper(conf *Config, preloadedAssets map[string][]string) AssetURLHelperFunc {
 	return func(key string) (string, error) {
-		var err error
-
-		var assets map[string][]string
-		if conf.IsDev {
-			assets, err = readManifest(conf)
-			if err != nil {
-				return "", err
-			}
-		} else {
-			assets = preloadedAssets
-		}
-
 		parts := strings.Split(key, ".")
 		kind := parts[len(parts)-1]
-		//log.Println("showing assets:", key, parts, kind)
 
-		v, ok := assets[key]
-		if !ok {
-			message := "go-webpack: Asset file '" + key + "' not found in manifest"
-			if conf.Verbose {
-				log.Printf("%s. Manifest contents:", message)
-				for k, a := range assets {
-					log.Printf("%s: %s", k, a)
-				}
-			}
-			if conf.IgnoreMissing {
-				return "", nil
-			}
-			return "", errors.New(message)
+		urls, err := getValues(key, kind, conf, preloadedAssets)
+		if err != nil {
+			return "", err
 		}
 
 		buf := []string{}
-		for _, s := range v {
-			if strings.HasSuffix(s, "."+kind) {
-				url := s
-				if len(conf.AssetHost) > 0 {
-					url = conf.AssetHost + url
-				}
-				buf = append(buf, url)
-			} else {
-				log.Println("skip asset", s, ": bad type")
-			}
+		for _, url := range urls {
+			buf = append(buf, url)
 		}
 		// this seems very wrong for multiple urls, but we don't have that problem right now :grimacing:
 		return strings.Join(buf, ","), nil

--- a/webpack_test.go
+++ b/webpack_test.go
@@ -6,7 +6,8 @@ import (
 
 func TestManifestAssetHelper(t *testing.T) {
 	assets := map[string][]string{
-		"main.js": []string{"main.1.js", "main.2.js"},
+		"main.js":   []string{"main.1.js", "main.2.js"},
+		"image.png": []string{"image.3.png"},
 	}
 
 	tagHelper := createAssetTagHelper(&Config{
@@ -24,6 +25,17 @@ func TestManifestAssetHelper(t *testing.T) {
 	expectedHTML :=
 		`<script type="text/javascript" src="main.1.js"></script>
 <script type="text/javascript" src="main.2.js"></script>`
+
+	if string(html) != expectedHTML {
+		t.Fatalf("unexpected <script> tags\nexpected:\n%s\nactual:\n%s", expectedHTML, html)
+	}
+
+	html, err = tagHelper("image.png")
+	if err != nil {
+		t.Fatalf("error %v returned from asset tag helper for valid asset", err)
+	}
+	expectedHTML =
+		`<img src="image.3.png"></img>`
 
 	if string(html) != expectedHTML {
 		t.Fatalf("unexpected <script> tags\nexpected:\n%s\nactual:\n%s", expectedHTML, html)
@@ -53,7 +65,8 @@ func TestManifestAssetHelper(t *testing.T) {
 
 func TestManifestAssetHelperWithAssetHost(t *testing.T) {
 	assets := map[string][]string{
-		"main.js": []string{"main.1.js"},
+		"main.js":   []string{"main.1.js"},
+		"image.png": []string{"image.3.png"},
 	}
 
 	tagHelper := createAssetTagHelper(&Config{
@@ -75,6 +88,17 @@ func TestManifestAssetHelperWithAssetHost(t *testing.T) {
 
 	if string(html) != expectedHTML {
 		t.Fatalf("unexpected <script> tag\nexpected:\n%s\nactual:\n%s", expectedHTML, html)
+	}
+
+	html, err = tagHelper("image.png")
+	if err != nil {
+		t.Fatalf("error %v returned from asset tag helper for valid asset", err)
+	}
+	expectedHTML =
+		`<img src="//cdn.com/prefix/image.3.png"></img>`
+
+	if string(html) != expectedHTML {
+		t.Fatalf("unexpected <script> tags\nexpected:\n%s\nactual:\n%s", expectedHTML, html)
 	}
 
 	url, err := urlHelper("main.js")

--- a/webpack_test.go
+++ b/webpack_test.go
@@ -8,6 +8,7 @@ func TestManifestAssetHelper(t *testing.T) {
 	assets := map[string][]string{
 		"main.js":   []string{"main.1.js", "main.2.js"},
 		"image.png": []string{"image.3.png"},
+		"image.svg": []string{"image.4.svg"},
 	}
 
 	tagHelper := createAssetTagHelper(&Config{
@@ -41,6 +42,17 @@ func TestManifestAssetHelper(t *testing.T) {
 		t.Fatalf("unexpected <script> tags\nexpected:\n%s\nactual:\n%s", expectedHTML, html)
 	}
 
+	html, err = tagHelper("image.svg")
+	if err != nil {
+		t.Fatalf("error %v returned from asset tag helper for valid asset", err)
+	}
+	expectedHTML =
+		`<img src="image.4.svg"></img>`
+
+	if string(html) != expectedHTML {
+		t.Fatalf("unexpected <script> tags\nexpected:\n%s\nactual:\n%s", expectedHTML, html)
+	}
+
 	url, err := urlHelper("main.js")
 	if err != nil {
 		t.Fatalf("error %v returned from asset url helper for valid asset", err)
@@ -67,6 +79,7 @@ func TestManifestAssetHelperWithAssetHost(t *testing.T) {
 	assets := map[string][]string{
 		"main.js":   []string{"main.1.js"},
 		"image.png": []string{"image.3.png"},
+		"image.svg": []string{"image.4.svg"},
 	}
 
 	tagHelper := createAssetTagHelper(&Config{
@@ -96,6 +109,17 @@ func TestManifestAssetHelperWithAssetHost(t *testing.T) {
 	}
 	expectedHTML =
 		`<img src="//cdn.com/prefix/image.3.png"></img>`
+
+	if string(html) != expectedHTML {
+		t.Fatalf("unexpected <script> tags\nexpected:\n%s\nactual:\n%s", expectedHTML, html)
+	}
+
+	html, err = tagHelper("image.svg")
+	if err != nil {
+		t.Fatalf("error %v returned from asset tag helper for valid asset", err)
+	}
+	expectedHTML =
+		`<img src="//cdn.com/prefix/image.4.svg"></img>`
 
 	if string(html) != expectedHTML {
 		t.Fatalf("unexpected <script> tags\nexpected:\n%s\nactual:\n%s", expectedHTML, html)

--- a/webpack_test.go
+++ b/webpack_test.go
@@ -9,13 +9,17 @@ func TestManifestAssetHelper(t *testing.T) {
 		"main.js": []string{"main.1.js", "main.2.js"},
 	}
 
-	helper := createAssetHelper(&Config{
+	tagHelper := createAssetTagHelper(&Config{
 		Plugin: "manifest",
 	}, assets)
 
-	html, err := helper("main.js")
+	urlHelper := createAssetURLHelper(&Config{
+		Plugin: "manifest",
+	}, assets)
+
+	html, err := tagHelper("main.js")
 	if err != nil {
-		t.Fatalf("error %v returned from asset helper for valid asset", err)
+		t.Fatalf("error %v returned from asset tag helper for valid asset", err)
 	}
 	expectedHTML :=
 		`<script type="text/javascript" src="main.1.js"></script>
@@ -25,8 +29,23 @@ func TestManifestAssetHelper(t *testing.T) {
 		t.Fatalf("unexpected <script> tags\nexpected:\n%s\nactual:\n%s", expectedHTML, html)
 	}
 
+	url, err := urlHelper("main.js")
+	if err != nil {
+		t.Fatalf("error %v returned from asset url helper for valid asset", err)
+	}
+
+	expectedURL := "main.1.js,main.2.js"
+	if url != expectedURL {
+		t.Fatalf("unexpected url\nexpected:\n%s\nactual:\n%s", expectedURL, url)
+	}
+
 	// IgnoreMissing = false
-	_, err = helper("maiin.js")
+	_, err = tagHelper("maiin.js")
+	if err == nil {
+		t.Fatalf("error nil when it shouldn't have been")
+	}
+
+	_, err = urlHelper("maiin.js")
 	if err == nil {
 		t.Fatalf("error nil when it shouldn't have been")
 	}
@@ -34,28 +53,47 @@ func TestManifestAssetHelper(t *testing.T) {
 
 func TestManifestAssetHelperWithAssetHost(t *testing.T) {
 	assets := map[string][]string{
-		"main.js": []string{"main.1.js", "main.2.js"},
+		"main.js": []string{"main.1.js"},
 	}
 
-	helper := createAssetHelper(&Config{
+	tagHelper := createAssetTagHelper(&Config{
 		Plugin:    "manifest",
 		AssetHost: "//cdn.com/prefix/",
 	}, assets)
 
-	html, err := helper("main.js")
+	urlHelper := createAssetURLHelper(&Config{
+		Plugin:    "manifest",
+		AssetHost: "//cdn.com/prefix/",
+	}, assets)
+
+	html, err := tagHelper("main.js")
 	if err != nil {
-		t.Fatalf("error %v returned from asset helper for valid asset", err)
+		t.Fatalf("error %v returned from asset tag helper for valid asset", err)
 	}
 	expectedHTML :=
-		`<script type="text/javascript" src="//cdn.com/prefix/main.1.js"></script>
-<script type="text/javascript" src="//cdn.com/prefix/main.2.js"></script>`
+		`<script type="text/javascript" src="//cdn.com/prefix/main.1.js"></script>`
 
 	if string(html) != expectedHTML {
-		t.Fatalf("unexpected <script> tags\nexpected:\n%s\nactual:\n%s", expectedHTML, html)
+		t.Fatalf("unexpected <script> tag\nexpected:\n%s\nactual:\n%s", expectedHTML, html)
+	}
+
+	url, err := urlHelper("main.js")
+	if err != nil {
+		t.Fatalf("error %v returned from asset url helper for valid asset", err)
+	}
+
+	expectedURL := "//cdn.com/prefix/main.1.js"
+	if url != expectedURL {
+		t.Fatalf("unexpected url\nexpected:\n%s\nactual:\n%s", expectedURL, url)
 	}
 
 	// IgnoreMissing = false
-	_, err = helper("maiin.js")
+	_, err = tagHelper("maiin.js")
+	if err == nil {
+		t.Fatalf("error nil when it shouldn't have been")
+	}
+
+	_, err = urlHelper("maiin.js")
 	if err == nil {
 		t.Fatalf("error nil when it shouldn't have been")
 	}


### PR DESCRIPTION
We have a need for both, given our new asset pipeline:

```
{{ asset "image.png" }}
```

should emit an `<img>` tag.

For times where we have alt-text, we really need to be able to do:

```
<img src="{{ assetURL "image.png" }}" alt="Image Alt Text" />
```

Ideally the second case will be handled as additional args to the helper, but this is a little easier to implement for now.